### PR TITLE
Remove alpha tag in docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ docker network create meilisearch-network
 ```
 
 ```bash
-$ docker run -it --rm -p 8000:80 --network=meilisearch-network shokme/meilisearch-dashboard:alpha
+$ docker run -it --rm -p 8000:80 --network=meilisearch-network shokme/meilisearch-dashboard
 ```
 
 ### Run MeiliSearch


### PR DESCRIPTION
I did not find any `alpha` tag in your hub: https://hub.docker.com/r/shokme/meilisearch-dashboard/tags 🙂

<img width="855" alt="Capture d’écran 2020-08-20 à 20 45 09" src="https://user-images.githubusercontent.com/20380692/90813119-640c9f80-e327-11ea-9f96-56e07ae5e9b2.png">